### PR TITLE
Fix navbar menu background color on hover

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -199,3 +199,7 @@ blink {
 @keyframes blink {
   to { visibility: hidden; }
 }
+
+.pure-menu-active>.pure-menu-link, .pure-menu-link:focus, .pure-menu-link:hover {
+    background-color: #222;
+}


### PR DESCRIPTION
I changed menu background color from light-grey to dark-grey
Before:
<img width="565" alt="2017-11-27 23 54 48" src="https://user-images.githubusercontent.com/21139056/33288760-69347c82-d3ce-11e7-9b6a-5faf5ed63ad9.png">

Now:
<img width="531" alt="2017-11-27 23 57 36" src="https://user-images.githubusercontent.com/21139056/33288877-c9c5b6f6-d3ce-11e7-8eb1-c3fee5dcef44.png">

